### PR TITLE
feature:create jtbc crawler

### DIFF
--- a/app/crawler/jtbc/api.py
+++ b/app/crawler/jtbc/api.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+from typing import List
+
+import aiohttp
+
+from app.crawler.base import Article, BaseNewsCrawler
+from common.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class JTBCNewsApiCrawler(BaseNewsCrawler):
+    """
+    JTBC 뉴스 API 크롤러
+    """
+
+    BASE_URL = "https://news-api.jtbc.co.kr/v1/get/contents/section/list/articles"
+
+    async def fetch_articles(self) -> List[Article]:
+        logger.info("[JTBC] 뉴스 API 요청 시작")
+
+        articles: List[Article] = []
+
+        # 오늘 날짜 가져오기
+        today = datetime.now().strftime("%Y-%m-%d")
+        logger.info(f"[JTBC] 오늘 날짜: {today}")
+
+        timeout = aiohttp.ClientTimeout(total=30)
+        connector = aiohttp.TCPConnector(limit=10, ssl=False)
+
+        try:
+            async with aiohttp.ClientSession(
+                connector=connector, timeout=timeout
+            ) as session:
+                params = {"pageNo": 1, "pageSize": 20, "articleListType": "ARTICLE"}
+
+                async with session.get(self.BASE_URL, params=params) as response:
+                    if response.status == 200:
+                        data = await response.json()
+                        news_list = data["data"]["list"]
+                        for item in news_list:
+                            # 오늘 날짜의 기사만 추가
+                            pub_date = item.get("publicationDate", "").split("T")[0]
+                            if pub_date == today:
+                                title = item.get("articleTitle")
+                                article_idx = item.get("articleIdx")
+                                if title and article_idx:
+                                    link = (
+                                        f"https://news.jtbc.co.kr/article/{article_idx}"
+                                    )
+                                    articles.append({"title": title, "link": link})
+                    else:
+                        logger.error(f"[JTBC] 요청 실패 - 상태 코드: {response.status}")
+
+        except Exception as e:
+            logger.error(f"[JTBC] 뉴스 수집 중 오류 발생: {str(e)}")
+
+        logger.info(f"[JTBC] 총 {len(articles)}개의 기사 수집 완료")
+        return articles

--- a/app/crawler/registry.py
+++ b/app/crawler/registry.py
@@ -1,9 +1,11 @@
 from app.crawler.base import BaseNewsCrawler
+from app.crawler.jtbc.api import JTBCNewsApiCrawler
 from app.crawler.mbc.hybrid import HybridMbcCrawler
 from app.crawler.ytn.api import YtnNewsApiCrawler
 
 CRAWLERS: dict[str, BaseNewsCrawler] = {
     "mbc": HybridMbcCrawler(),
     "ytn": YtnNewsApiCrawler(),
+    "jtbc": JTBCNewsApiCrawler(),
     # 향후 "kbs": KbsNewsCrawler(), 등으로 쉽게 확장 가능
 }


### PR DESCRIPTION
# JTBC 뉴스 크롤러 추가

## 추가 내용
- JTBC 뉴스 API를 활용한 새로운 크롤러 추가
- `app/crawler/jtbc/api.py` 파일 생성
- `BaseNewsCrawler`를 상속받아 구현

## 구현 내용
- JTBC 뉴스 API (`news-api.jtbc.co.kr`)를 통한 뉴스 데이터 수집
- 오늘 날짜의 뉴스만 필터링하여 수집
- 기사 제목과 링크 정보 추출

## 기술 스택
- `aiohttp`: 비동기 HTTP 요청 처리
- `BaseNewsCrawler`: 크롤러 기본 클래스 상속
- 공통 로깅 시스템 활용

## 피드백 이후 수정된 사항
- 오늘 날짜의 기사만 수집하는 로직 삭제
- early return 패턴을 적용하여 코드 가독성 향상
- API 호출시 데이터 구조 변화에 따른 에러가 발생할 수 있는 코드 수정