### PR TITLE
Feat/jtbc api implementation

### DIFF
--- a/app/crawler/jtbc/README.md
+++ b/app/crawler/jtbc/README.md
@@ -1,0 +1,190 @@
+# JTBC 뉴스 API 문서
+
+## API 엔드포인트
+
+### 섹션별 기사 목록 조회
+
+```
+GET https://news-api.jtbc.co.kr/v1/get/contents/section/list/articles
+```
+
+#### 요청 파라미터
+- `pageNo`: 페이지 번호 (필수, 기본값: 1)
+- `pageSize`: 페이지 크기 (필수, 기본값: 10)
+- `articleListType`: 기사 목록 유형 (필수, 기본값: "ARTICLE")
+- `sectionIdx`: 섹션 인덱스 (선택, 예: 10 - 정치)
+
+#### 응답 데이터 구조
+
+```typescript
+interface Article {
+  articleIdx: string;                  // 기사 고유 ID (예: "NB12243049")
+  articleTitle: string;                // 기사 제목
+  articleMobileTitle: string | null;   // 모바일용 기사 제목
+  articleInnerTextContent: string;     // 기사 내용
+  rank: number | null;                 // 순위
+  articleThumbnailImgUrl: string;      // 썸네일 이미지 URL
+  articleThumbnailImageViewType: string; // 썸네일 이미지 뷰 타입
+  isVideoView: boolean;                // 비디오 뷰 여부
+  vodInfo: {                           // VOD 정보
+    videoIdx: string;                  // 비디오 ID
+    videoType: {                       // 비디오 타입
+      code: string;                    // 코드
+      name: string;                    // 이름
+    };
+    playTime: string;                  // 재생 시간
+    vodThumbnailImgUrl: string | null; // VOD 썸네일 이미지 URL
+  } | null;
+  publicationDate: string;             // 발행일 (ISO 8601 형식)
+  journalistName: string | null;       // 기자 이름
+  isScrap: boolean;                    // 스크랩 여부
+  readDate: string | null;             // 읽은 날짜
+  expressionDate: string | null;       // 표현 날짜
+  scrapDate: string | null;            // 스크랩 날짜
+  bulletType: string | null;           // 불렛 타입
+  isComment: boolean;                  // 댓글 여부
+}
+
+interface ArticlesResponse {
+  resultCode: string;                  // 응답 코드
+  resultMessage: string;               // 응답 메시지
+  data: {
+    currentPage: number;               // 현재 페이지
+    pageSize: number;                  // 페이지 크기
+    totalPages: number;                // 전체 페이지 수
+    totalElements: number;             // 전체 요소 수
+    list: Article[];                   // 기사 목록
+  };
+}
+```
+
+#### 응답 예시
+
+```json
+{
+	"resultCode": "00",
+	"resultMessage": "성공적으로 조회하였습니다.",
+	"data": {
+		"currentPage": 1,
+		"pageSize": 10,
+		"totalPages": 47958,
+		"totalElements": 479573,
+		"list": [
+			{
+				"articleIdx": "NB12243049",
+				"articleTitle": "한미 협상카드 떠오른 '알래스카 LNG'…사업성 논란에 '신중론'",
+				"articleMobileTitle": null,
+				"articleInnerTextContent": "[앵커]\n\n상호 관세 문제를 놓고 우리 정부가 다음 주 미국과 본격 협상에 들어갑니다. 우리의 협상 카드로 거론되는 것 중 하나가 &#39;알래스카 가스관 개발 사업&#39;인데, 신중하게 접근해야 한다는 지적도 나옵니다.\n\n...",
+				"rank": null,
+				"articleThumbnailImgUrl": "https://thumb.jtbc.co.kr/photo/r600x0/news/cms/etc/2025/04/16/20250416193905600001.jpg",
+				"articleThumbnailImageViewType": "WIDTH",
+				"isVideoView": false,
+				"vodInfo": {
+					"videoIdx": "ND10696094",
+					"videoType": {
+						"code": "NORMAL",
+						"name": "일반"
+					},
+					"playTime": "02:01",
+					"vodThumbnailImgUrl": null
+				},
+				"publicationDate": "2025-04-16T19:37",
+				"journalistName": null,
+				"isScrap": false,
+				"readDate": null,
+				"expressionDate": null,
+				"scrapDate": null,
+				"bulletType": null,
+				"isComment": false
+			}
+		]
+	}
+}
+```
+
+## 데이터 모델
+
+### JtbcArticleMetadata
+
+JTBC 뉴스의 메타데이터를 정의하는 Pydantic 모델입니다.
+
+```python
+class JtbcArticleMetadata(ArticleMetadata):
+    article_id: str     # 기사 고유 ID (articleIdx)
+    category: str       # 뉴스 카테고리 (섹션 이름)
+    has_video: bool = False  # 비디오 포함 여부
+    video_id: Optional[str] = None  # 비디오 ID (vodInfo.videoIdx)
+```
+
+### ArticleDTO[JtbcArticleMetadata]
+
+뉴스 기사 데이터를 표현하는 DTO 모델입니다.
+
+```python
+article_dto = ArticleDTO[JtbcArticleMetadata](
+    title="한미 협상카드 떠오른 '알래스카 LNG'…사업성 논란에 '신중론'",
+    url="https://news.jtbc.co.kr/article/NB12243049",
+    content="[앵커]\n\n상호 관세 문제를 놓고 우리 정부가 다음 주 미국과 본격 협상에...",
+    author="김기자",  # 기자 이름이 있는 경우
+    metadata=JtbcArticleMetadata(
+        platform="JTBC",
+        article_id="NB12243049",
+        category="정치",
+        has_video=True,  # 비디오가 있는 경우
+        video_id="ND10696094",  # 비디오 ID
+        collected_at=datetime.now(),
+    )
+)
+```
+
+## URL 구조
+
+### 기사 URL 패턴
+```
+https://news.jtbc.co.kr/article/[ARTICLE_ID]
+```
+
+- `[ARTICLE_ID]`: 기사 고유 ID (예: "NB12243049")
+
+## 섹션(카테고리) 코드
+
+| 코드 | 카테고리 |
+|------|----------|
+| 10   | 정치     |
+| 20   | 경제     |
+| 30   | 사회     |
+| 40   | 국제     |
+| 50   | 문화     |
+| 60   | 연예     |
+| 70   | 스포츠   |
+| 80   | 날씨     |
+
+## 크롤링 프로세스
+
+1. `CATEGORY_MAP`에 정의된 카테고리 코드와 이름을 사용합니다.
+2. 각 카테고리별로 기사 목록 API를 호출하여 기사 정보를 수집합니다.
+3. 각 기사에서 다음 정보를 추출합니다:
+   - 기사 제목 (`articleTitle`)
+   - 기사 ID (`articleIdx`)
+   - 기사 내용 요약 (`articleInnerTextContent`)
+   - 발행일 (`publicationDate`)
+   - 기자 이름 (`journalistName`)
+   - 비디오 정보 (`isVideoView`, `vodInfo.videoIdx`)
+4. 수집된 모든 카테고리의 기사를 취합하여 반환합니다.
+
+## 참고사항
+
+1. 기사 목록 API는 페이지네이션을 지원합니다. 
+   - 기본적으로 각 카테고리별로 첫 페이지만 조회합니다 (pageNo=1).
+   - 각 페이지당 10개의 기사를 가져옵니다 (pageSize=10).
+2. JTBC API 응답은 이미 JSON 형식으로 제공되므로 별도의 정제 과정이 필요하지 않습니다.
+3. 기사 내용은 `articleInnerTextContent` 필드에서 일부 추출하여 요약으로 사용합니다.
+4. 비디오 정보(`isVideoView` 및 `vodInfo`)는 메타데이터(`has_video`, `video_id`)로 저장됩니다.
+5. 기자 이름(`journalistName`)은 ArticleDTO의 `author` 필드에 저장됩니다.
+
+## 에러 처리
+
+1. HTTP 상태 코드가 200이 아닌 경우 빈 리스트를 반환합니다.
+2. 개별 기사 데이터 처리 중 오류가 발생하면 해당 기사는 건너뛰고 계속 진행합니다.
+3. API 요청 자체가 실패하면 빈 리스트를 반환합니다.
+4. 발행일 파싱에 실패한 경우 None으로 설정하고 계속 진행합니다. 

--- a/app/crawler/jtbc/api.py
+++ b/app/crawler/jtbc/api.py
@@ -1,11 +1,46 @@
-from typing import List
+from datetime import datetime
+from typing import Dict, List, Optional, TypedDict
 
 import aiohttp
 
-from app.crawler.base import Article, BaseNewsCrawler
+from app.crawler.base import BaseNewsCrawler
+from app.schemas.article import ArticleDTO, ArticleMetadata
 from common.utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+
+# JTBC 카테고리 코드 매핑
+CATEGORY_MAP = {
+    10: "정치",
+    20: "경제",
+    30: "사회",
+    40: "국제",
+    50: "문화",
+    60: "연예",
+    70: "스포츠",
+    80: "날씨",
+}
+
+
+class JtbcArticle(TypedDict):
+    """JTBC 기사 API 응답 데이터 구조"""
+
+    articleIdx: str  # 기사 고유 ID
+    articleTitle: str  # 기사 제목
+    articleInnerTextContent: str  # 기사 내용
+    publicationDate: str  # 발행일
+    journalistName: str  # 기자 이름
+    isVideoView: bool  # 비디오 여부
+    vodInfo: dict  # 비디오 정보
+
+
+class JtbcArticleMetadata(ArticleMetadata):
+    """JTBC 뉴스 메타데이터 모델"""
+
+    article_id: str  # 기사 고유 ID
+    has_video: bool = False  # 비디오 포함 여부
+    video_id: Optional[str] = None  # 비디오 ID
 
 
 class JTBCNewsApiCrawler(BaseNewsCrawler):
@@ -15,22 +50,41 @@ class JTBCNewsApiCrawler(BaseNewsCrawler):
 
     BASE_URL = "https://news-api.jtbc.co.kr/v1/get/contents/section/list/articles"
 
-    async def fetch_articles(self) -> List[Article]:
-        logger.info("[JTBC] 뉴스 API 요청 시작")
+    async def fetch_articles_by_category(
+        self, category_code: int
+    ) -> list[ArticleDTO[JtbcArticleMetadata]]:
+        """
+        특정 카테고리(섹션)의 뉴스 기사 수집
 
-        articles: List[Article] = []
-        timeout = aiohttp.ClientTimeout(total=30)
-        connector = aiohttp.TCPConnector(limit=10, ssl=False)
+        Args:
+            category_code: 카테고리 코드 (예: 10 - 정치)
+
+        Returns:
+            list[ArticleDTO[JtbcArticleMetadata]]: 수집된 기사 목록
+        """
+        # 카테고리명 조회
+        category_name = CATEGORY_MAP.get(category_code, f"카테고리{category_code}")
+
+        logger.info(
+            f"[JTBC] '{category_name}({category_code})' 카테고리 기사 수집 시작"
+        )
+
+        articles: list[ArticleDTO[JtbcArticleMetadata]] = []
 
         try:
-            async with aiohttp.ClientSession(
-                connector=connector, timeout=timeout
-            ) as session:
-                params = {"pageNo": 1, "pageSize": 20, "articleListType": "ARTICLE"}
+            async with aiohttp.ClientSession() as session:
+                params = {
+                    "pageNo": 1,
+                    "pageSize": 10,
+                    "articleListType": "ARTICLE",
+                    "sectionIdx": category_code,
+                }
 
                 async with session.get(self.BASE_URL, params=params) as response:
                     if response.status != 200:
-                        logger.error(f"[JTBC] 요청 실패 - 상태 코드: {response.status}")
+                        logger.error(
+                            f"[JTBC] '{category_name}' 카테고리 요청 실패 - 상태 코드: {response.status}"
+                        )
                         return articles
 
                     data = await response.json()
@@ -38,18 +92,99 @@ class JTBCNewsApiCrawler(BaseNewsCrawler):
 
                     for item in news_list:
                         try:
+                            # 필수 필드 확인
                             title = item.get("articleTitle")
                             article_idx = item.get("articleIdx")
+
                             if not title or not article_idx:
                                 continue
 
-                            link = f"https://news.jtbc.co.kr/article/{article_idx}"
-                            articles.append({"title": title, "link": link})
+                            # 메타데이터 및 컨텐츠 추출
+                            url = f"https://news.jtbc.co.kr/article/{article_idx}"
+                            content = self._extract_content(
+                                item.get("articleInnerTextContent", "")
+                            )
+                            published_at = self._parse_date(item.get("publicationDate"))
+                            author = item.get("journalistName")
+
+                            # 비디오 정보 추출
+                            has_video = item.get("isVideoView", False)
+                            video_id = None
+                            if vod_info := item.get("vodInfo"):
+                                has_video = True
+                                video_id = vod_info.get("videoIdx")
+
+                            # 메타데이터 생성
+                            metadata = JtbcArticleMetadata(
+                                platform="JTBC",
+                                category=category_name,
+                                article_id=article_idx,
+                                published_at=published_at,
+                                collected_at=datetime.now(),
+                                updated_at=datetime.now(),
+                                has_video=has_video,
+                                video_id=video_id,
+                            )
+
+                            # ArticleDTO 생성
+                            article_dto = ArticleDTO[JtbcArticleMetadata](
+                                title=title,
+                                url=url,
+                                content=content,
+                                author=author,
+                                metadata=metadata,
+                            )
+
+                            articles.append(article_dto)
+
                         except Exception as e:
                             logger.warning(f"[JTBC] 기사 정보 처리 중 오류: {str(e)}")
 
         except Exception as e:
-            logger.error(f"[JTBC] 뉴스 수집 중 오류 발생: {str(e)}")
+            logger.error(
+                f"[JTBC] '{category_name}' 카테고리 뉴스 수집 중 오류 발생: {str(e)}"
+            )
 
-        logger.info(f"[JTBC] 총 {len(articles)}개의 기사 수집 완료")
+        logger.info(
+            f"[JTBC] '{category_name}' 카테고리 총 {len(articles)}개의 기사 수집 완료"
+        )
         return articles
+
+    def _parse_date(self, date_str: str) -> datetime | None:
+        """발행일 문자열을 datetime 객체로 파싱"""
+        if not date_str:
+            return None
+
+        try:
+            return datetime.fromisoformat(date_str)
+        except (ValueError, TypeError):
+            logger.warning(f"[JTBC] 발행일 파싱 실패: {date_str}")
+            return None
+
+    def _extract_content(self, text: str, max_length: int = 200) -> str:
+        """기사 내용에서 요약 추출"""
+        if not text:
+            return ""
+
+        if len(text) <= max_length:
+            return text
+
+        return text[:max_length] + "..."
+
+    async def fetch_articles(self) -> list[ArticleDTO[JtbcArticleMetadata]]:
+        """
+        JTBC 뉴스 기사 수집
+        모든 카테고리의 기사를 수집합니다.
+
+        Returns:
+            list[ArticleDTO[JtbcArticleMetadata]]: 수집된 기사 목록
+        """
+        all_articles: list[ArticleDTO[JtbcArticleMetadata]] = []
+
+        # CATEGORY_MAP의 모든 카테고리에 대해 기사 수집
+        for category_code in CATEGORY_MAP:
+            category_articles = await self.fetch_articles_by_category(category_code)
+            all_articles.extend(category_articles)
+
+        logger.info(f"[JTBC] 전체 {len(all_articles)}개의 기사 수집 완료")
+        return all_articles


### PR DESCRIPTION
# JTBC 뉴스 API 크롤러 개선 및 문서화

## 주요 변경사항

이번 PR에서는 JTBC 뉴스 API 크롤러의 구조를 단순화하고, 메타데이터 모델을 확장하였으며, 관련 문서를 추가하였습니다.

### 1. 크롤러 구조 개선 (`app/crawler/jtbc/api.py`)
- 섹션 API 호출 대신 하드코딩된 `CATEGORY_MAP` 사용으로 구조 단순화
- 코드 중복 제거 및 헬퍼 메소드 모듈화
- `fetch_articles` 및 `fetch_articles_by_category` 메소드 최적화

### 2. 메타데이터 모델 확장
- 비디오 정보 관련 필드 추가 (`has_video`, `video_id`)
- 콘텐츠 추출 및 요약 로직 개선
- 날짜 파싱 기능 강화

### 3. 문서화 (`app/crawler/jtbc/README.md`)
- JTBC 뉴스 API 상세 설명
- 카테고리 코드 매핑 테이블 제공
- 응답 데이터 구조 및 필드 설명
- 실제 사용 예시 코드 추가