### PR TITLE
feat: API 응답 데이터 처리를 위한 BaseApiModel 클래스 추가

### DIFF
--- a/app/schemas/api_models.py
+++ b/app/schemas/api_models.py
@@ -1,0 +1,41 @@
+from typing import Any, ClassVar, Dict, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class BaseApiModel(BaseModel):
+    """API 응답을 위한 기본 Pydantic 모델"""
+
+    model_config = {
+        "populate_by_name": True,
+        "extra": "ignore",
+    }
+
+    # 기본값 매핑을 위한 클래스 변수 (서브클래스에서 오버라이드)
+    _default_values: ClassVar[Dict[str, Any]] = {}
+
+    @model_validator(mode="before")
+    @classmethod
+    def set_defaults_for_none_values(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+        """None 값을 적절한 기본값으로 설정"""
+        if not isinstance(data, dict):
+            return data
+
+        # 자식 클래스에서 정의한 기본값 사용
+        defaults = cls._default_values
+
+        # None 값을 기본값으로 대체
+        for field, default in defaults.items():
+            if field in data and data[field] is None:
+                data[field] = default
+
+        return data
+
+    @classmethod
+    def safe_validate(cls, data: Dict[str, Any]) -> Optional["BaseApiModel"]:
+        """예외 처리가 포함된 안전한 검증 메서드"""
+        try:
+            return cls.model_validate(data)
+        except Exception as e:
+            # 로깅 추가 가능
+            return None


### PR DESCRIPTION
# API 응답 데이터 처리를 위한 BaseApiModel 클래스 추가

## 변경 내용

이 PR은 뉴스 API 응답 데이터를 처리하는 방식을 개선하기 위해 Pydantic 기반의 `BaseApiModel` 클래스를 추가합니다. 이를 통해 각 뉴스 소스별(YTN, MBC, JTBC) API 모델에서 중복되던 코드를 제거하고, None 값 처리와 데이터 검증을 일관된 방식으로 수행할 수 있게 되었습니다.

### 주요 변경 사항

* `app/schemas/api_models.py` 파일 신규 추가
  * `BaseApiModel` 클래스 구현
  * None 값을 기본값으로 대체하는 `model_validator` 추가
  * 안전한 모델 검증을 위한 `safe_validate` 메소드 제공

* 뉴스 API 모델 리팩토링
  * YTN, MBC, JTBC API 모델 클래스를 `BaseApiModel`을 상속받도록 수정
  * 각 모델에서 기본값을 `_defau    lt_values` 사전으로 정의
  * 중복 코드 제거 및 일관된 검증 로직 적용
 
## 테스트 결과

* 모든 뉴스 API 크롤러(YTN, MBC, JTBC)에서 기존과 동일하게 데이터를 수집하는 것을 확인
* None 값이 포함된 API 응답도 적절하게 처리되는 것을 확인

## 검토 요청 사항

* `BaseApiModel`의 설계가 적절한지 검토 요청
* 추가 개선 사항이나 리팩토링이 필요한 부분이 있는지 검토 요청

## 관련 이슈

issue #19 
