### PR TITLE
feat: create discord bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ news-alert-system/
 │   │   ├── registry.py     # 크롤러 레지스트리
 │   │   └── base.py         # 기본 크롤러 인터페이스
 │   ├── processor/          # 텍스트 전처리 및 키워드 분석
-│   ├── notifier/           # Slack 알림 모듈
+│   ├── notifier/           # discord 알림 모듈
 │   ├── api/                # FastAPI 엔드포인트
 │   ├── models/             # DB 모델 정의
 │   └── schemas/            # Pydantic 스키마

--- a/app/publisher/discord/README.md
+++ b/app/publisher/discord/README.md
@@ -1,0 +1,81 @@
+# Discord 뉴스 알림 봇
+
+## 소개
+
+이 모듈은 Discord를 통해 뉴스 알림을 제공하는 간단한 봇을 구현합니다. 크롤링되어 정제된 데이터(ArticleDTO)를 이용해 채널 채팅방에 타이틀, 링크, 설명을 전송합니다.
+
+## 기능
+
+- 뉴스 기사 알림 전송 (임베드 형식)
+- 정제된 ArticleDTO를 이용한 간단한 메시지 포맷팅
+
+## 사용 방법
+
+### 봇 설정하기
+
+1. [Discord Developer Portal](https://discord.com/developers/applications)에서 봇을 생성하고 토큰을 얻습니다.
+2. 프로젝트 루트에 `.env` 파일을 생성하고 다음 내용을 추가합니다:
+
+```text
+# MongoDB 연결 설정
+MONGODB_URL=mongodb://root:1234@localhost:27017
+MONGODB_DB_NAME=news_alert
+
+# Discord 봇 설정
+DISCORD_BOT_TOKEN=your_discord_bot_token_here
+
+# 로깅 설정
+LOG_LEVEL=INFO
+```
+
+3. `DISCORD_BOT_TOKEN` 값을 Discord Developer Portal에서 얻은 토큰으로 변경합니다.
+
+### 봇 실행하기
+
+다음 명령어로 봇을 실행합니다:
+
+```bash
+python scripts/run_discord_bot.py
+```
+
+### 코드에서 사용하기
+
+다음과 같이 코드에서 뉴스 알림을 전송할 수 있습니다:
+
+```python
+from app.notifier.discord.bot import NewsAlertBot
+
+# 봇 인스턴스 생성
+bot = NewsAlertBot()
+
+# ArticleDTO 객체와 채널 ID가 있을 때
+await bot.send_news_alert(article_dto, channel_id)
+```
+
+## 개발자 정보
+
+### 코드 구조
+
+- `interfaces.py`: 메시지 포맷팅 인터페이스를 정의합니다.
+  - `MessageFormatter`: 메시지 포맷팅 인터페이스
+
+- `services.py`: 인터페이스 구현체를 제공합니다.
+  - `NewsEmbedFormatter`: 뉴스 임베드 포매터 구현
+
+- `bot.py`: Discord 봇 구현을 담당합니다.
+  - `NewsAlertBot`: 메인 봇 클래스
+  - `run_bot()`: 봇 실행 함수
+
+### 확장하기
+
+새로운 포맷터를 추가하려면 `MessageFormatter` 인터페이스를 구현하면 됩니다:
+
+```python
+from app.notifier.discord.interfaces import MessageFormatter
+
+class SimpleMessageFormatter(MessageFormatter):
+    """간단한 포맷의 메시지 포매터"""
+    
+    def create_embed(self, article):
+        # 간단한 임베드 생성 로직
+        return discord.Embed(title=article.title, url=article.url) 

--- a/app/publisher/discord/bot.py
+++ b/app/publisher/discord/bot.py
@@ -1,0 +1,113 @@
+import os
+from typing import List, Optional
+
+import discord
+from discord.ext import commands
+from dotenv import load_dotenv
+
+from app.publisher.discord.interfaces import MessageFormatter
+from app.publisher.discord.services import NewsEmbedFormatter
+from app.schemas.article import ArticleDTO, ArticleMetadata
+from common.utils.logger import get_logger
+
+# 환경 변수 로드
+load_dotenv()
+
+# 로거 설정
+logger = get_logger(__name__)
+
+
+class NewsAlertBot(commands.Bot):
+    """
+    뉴스 알림을 위한 Discord 봇 클래스
+
+    비동기 초기화와 이벤트 핸들링을 지원하는 봇 클래스입니다.
+    """
+
+    def __init__(
+        self, command_prefix: str = "!", formatter: MessageFormatter | None = None
+    ):
+        """
+        Discord 봇 초기화
+
+        Args:
+            command_prefix: 명령어 접두사 (기본값: "!")
+            formatter: 메시지 포맷터 (기본값: None, 자동 생성)
+        """
+        intents = discord.Intents.default()
+        intents.message_content = True
+
+        super().__init__(
+            command_prefix=command_prefix,
+            intents=intents,
+        )
+
+        # 봇 토큰 확인
+        self.token = os.getenv("DISCORD_BOT_TOKEN")
+        if not self.token:
+            raise ValueError("DISCORD_BOT_TOKEN 환경 변수가 설정되지 않았습니다.")
+
+        # 메시지 포맷터 설정
+        self.formatter = formatter or NewsEmbedFormatter()
+
+    async def on_ready(self):
+        """봇이 준비되었을 때 호출되는 이벤트 핸들러"""
+        logger.info(f"봇 '{self.user}'이(가) 로그인했습니다!")
+        logger.info(f"봇이 {len(self.guilds)}개의 서버에 연결되어 있습니다.")
+
+        # 봇 상태 설정
+        await self.change_presence(
+            activity=discord.Activity(
+                type=discord.ActivityType.watching, name="뉴스 속보"
+            )
+        )
+
+    async def send_news_alert(
+        self, article: ArticleDTO[ArticleMetadata], channel_id: int
+    ) -> bool:
+        """
+        특정 채널에 뉴스 알림을 전송합니다.
+
+        Args:
+            article: 알림을 보낼 뉴스 기사
+            channel_id: 알림을 보낼 채널 ID
+
+        Returns:
+            bool: 알림 전송 성공 여부
+        """
+        # 채널 검증
+        channel = self.get_channel(channel_id)
+        if not channel:
+            logger.warning(f"채널을 찾을 수 없음: {channel_id}")
+            return False
+
+        try:
+            # 임베드 생성
+            embed = self.formatter.create_embed(article)
+
+            # 알림 전송
+            await channel.send(embed=embed)
+            logger.info(f"채널 {channel_id}에 뉴스 알림 전송: {article.title}")
+            return True
+        except Exception as e:
+            logger.error(f"알림 전송 중 오류 발생: {str(e)}")
+            return False
+
+
+async def run_bot():
+    """
+    Discord 봇을 실행합니다.
+
+    비동기 함수로 봇을 시작하고, 예외 처리를 수행합니다.
+    """
+    bot = NewsAlertBot()
+
+    try:
+        logger.info("Discord 봇 시작 중...")
+        await bot.start(bot.token)
+    except KeyboardInterrupt:
+        logger.info("키보드 인터럽트로 봇 종료")
+        await bot.close()
+    except Exception as e:
+        logger.error(f"봇 실행 중 오류 발생: {str(e)}")
+        await bot.close()

--- a/app/publisher/discord/interfaces.py
+++ b/app/publisher/discord/interfaces.py
@@ -1,0 +1,30 @@
+from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
+
+import discord
+
+from app.schemas.article import ArticleDTO, ArticleMetadata
+
+# 타입 변수 정의
+T = TypeVar("T", bound=ArticleMetadata)
+
+
+class MessageFormatter(ABC, Generic[T]):
+    """
+    메시지 포맷팅 인터페이스
+
+    뉴스 알림 메시지를 포맷팅하는 기능을 제공합니다.
+    """
+
+    @abstractmethod
+    def create_embed(self, article: ArticleDTO[T]) -> discord.Embed:
+        """
+        임베드 메시지를 생성합니다.
+
+        Args:
+            article: 뉴스 기사
+
+        Returns:
+            discord.Embed: 생성된 임베드
+        """
+        pass

--- a/app/publisher/discord/services.py
+++ b/app/publisher/discord/services.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+
+import discord
+
+from app.publisher.discord.interfaces import MessageFormatter
+from app.schemas.article import ArticleDTO, ArticleMetadata
+from common.utils.logger import get_logger
+
+# 로거 설정
+logger = get_logger(__name__)
+
+
+class NewsEmbedFormatter(MessageFormatter[ArticleMetadata]):
+    """
+    뉴스 기사를 Discord 임베드로 포맷팅하는 클래스
+    """
+
+    def create_embed(self, article: ArticleDTO[ArticleMetadata]) -> discord.Embed:
+        """
+        뉴스 기사 임베드를 생성합니다.
+
+        Args:
+            article: 뉴스 기사
+
+        Returns:
+            discord.Embed: 생성된 임베드
+        """
+        # 발행 시간 포맷팅
+        published_at = "알 수 없음"
+        if article.metadata.published_at:
+            published_at = article.metadata.published_at.strftime("%Y-%m-%d %H:%M")
+
+        # 카테고리
+        category = article.metadata.category or "미분류"
+
+        # 임베드 생성
+        embed = discord.Embed(
+            title=article.title,
+            description=(
+                f"{article.content[:200]}..."
+                if article.content and len(article.content) > 200
+                else article.content
+            ),
+            url=article.url,
+            color=discord.Color.blue(),
+            timestamp=datetime.now(),
+        )
+
+        # 필드 추가
+        embed.add_field(name="언론사", value=article.metadata.platform, inline=True)
+        embed.add_field(name="카테고리", value=category, inline=True)
+        embed.add_field(name="발행 시간", value=published_at, inline=True)
+
+        # 푸터
+        embed.set_footer(text="실시간 뉴스 알림")
+
+        return embed

--- a/poetry.lock
+++ b/poetry.lock
@@ -182,6 +182,50 @@ tests = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothe
 tests-mypy = ["mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\""]
 
 [[package]]
+name = "audioop-lts"
+version = "0.2.1"
+description = "LTS Port of Python audioop"
+optional = false
+python-versions = ">=3.13"
+groups = ["main"]
+markers = "python_version >= \"3.13\""
+files = [
+    {file = "audioop_lts-0.2.1-cp313-abi3-macosx_10_13_universal2.whl", hash = "sha256:fd1345ae99e17e6910f47ce7d52673c6a1a70820d78b67de1b7abb3af29c426a"},
+    {file = "audioop_lts-0.2.1-cp313-abi3-macosx_10_13_x86_64.whl", hash = "sha256:e175350da05d2087e12cea8e72a70a1a8b14a17e92ed2022952a4419689ede5e"},
+    {file = "audioop_lts-0.2.1-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:4a8dd6a81770f6ecf019c4b6d659e000dc26571b273953cef7cd1d5ce2ff3ae6"},
+    {file = "audioop_lts-0.2.1-cp313-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d1cd3c0b6f2ca25c7d2b1c3adeecbe23e65689839ba73331ebc7d893fcda7ffe"},
+    {file = "audioop_lts-0.2.1-cp313-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ff3f97b3372c97782e9c6d3d7fdbe83bce8f70de719605bd7ee1839cd1ab360a"},
+    {file = "audioop_lts-0.2.1-cp313-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a351af79edefc2a1bd2234bfd8b339935f389209943043913a919df4b0f13300"},
+    {file = "audioop_lts-0.2.1-cp313-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2aeb6f96f7f6da80354330470b9134d81b4cf544cdd1c549f2f45fe964d28059"},
+    {file = "audioop_lts-0.2.1-cp313-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c589f06407e8340e81962575fcffbba1e92671879a221186c3d4662de9fe804e"},
+    {file = "audioop_lts-0.2.1-cp313-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fbae5d6925d7c26e712f0beda5ed69ebb40e14212c185d129b8dfbfcc335eb48"},
+    {file = "audioop_lts-0.2.1-cp313-abi3-musllinux_1_2_i686.whl", hash = "sha256:d2d5434717f33117f29b5691fbdf142d36573d751716249a288fbb96ba26a281"},
+    {file = "audioop_lts-0.2.1-cp313-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:f626a01c0a186b08f7ff61431c01c055961ee28769591efa8800beadd27a2959"},
+    {file = "audioop_lts-0.2.1-cp313-abi3-musllinux_1_2_s390x.whl", hash = "sha256:05da64e73837f88ee5c6217d732d2584cf638003ac72df124740460531e95e47"},
+    {file = "audioop_lts-0.2.1-cp313-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:56b7a0a4dba8e353436f31a932f3045d108a67b5943b30f85a5563f4d8488d77"},
+    {file = "audioop_lts-0.2.1-cp313-abi3-win32.whl", hash = "sha256:6e899eb8874dc2413b11926b5fb3857ec0ab55222840e38016a6ba2ea9b7d5e3"},
+    {file = "audioop_lts-0.2.1-cp313-abi3-win_amd64.whl", hash = "sha256:64562c5c771fb0a8b6262829b9b4f37a7b886c01b4d3ecdbae1d629717db08b4"},
+    {file = "audioop_lts-0.2.1-cp313-abi3-win_arm64.whl", hash = "sha256:c45317debeb64002e980077642afbd977773a25fa3dfd7ed0c84dccfc1fafcb0"},
+    {file = "audioop_lts-0.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3827e3fce6fee4d69d96a3d00cd2ab07f3c0d844cb1e44e26f719b34a5b15455"},
+    {file = "audioop_lts-0.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:161249db9343b3c9780ca92c0be0d1ccbfecdbccac6844f3d0d44b9c4a00a17f"},
+    {file = "audioop_lts-0.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5b7b4ff9de7a44e0ad2618afdc2ac920b91f4a6d3509520ee65339d4acde5abf"},
+    {file = "audioop_lts-0.2.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:72e37f416adb43b0ced93419de0122b42753ee74e87070777b53c5d2241e7fab"},
+    {file = "audioop_lts-0.2.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:534ce808e6bab6adb65548723c8cbe189a3379245db89b9d555c4210b4aaa9b6"},
+    {file = "audioop_lts-0.2.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d2de9b6fb8b1cf9f03990b299a9112bfdf8b86b6987003ca9e8a6c4f56d39543"},
+    {file = "audioop_lts-0.2.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f24865991b5ed4b038add5edbf424639d1358144f4e2a3e7a84bc6ba23e35074"},
+    {file = "audioop_lts-0.2.1-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bdb3b7912ccd57ea53197943f1bbc67262dcf29802c4a6df79ec1c715d45a78"},
+    {file = "audioop_lts-0.2.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:120678b208cca1158f0a12d667af592e067f7a50df9adc4dc8f6ad8d065a93fb"},
+    {file = "audioop_lts-0.2.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:54cd4520fc830b23c7d223693ed3e1b4d464997dd3abc7c15dce9a1f9bd76ab2"},
+    {file = "audioop_lts-0.2.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:d6bd20c7a10abcb0fb3d8aaa7508c0bf3d40dfad7515c572014da4b979d3310a"},
+    {file = "audioop_lts-0.2.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:f0ed1ad9bd862539ea875fb339ecb18fcc4148f8d9908f4502df28f94d23491a"},
+    {file = "audioop_lts-0.2.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e1af3ff32b8c38a7d900382646e91f2fc515fd19dea37e9392275a5cbfdbff63"},
+    {file = "audioop_lts-0.2.1-cp313-cp313t-win32.whl", hash = "sha256:f51bb55122a89f7a0817d7ac2319744b4640b5b446c4c3efcea5764ea99ae509"},
+    {file = "audioop_lts-0.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f0f2f336aa2aee2bce0b0dcc32bbba9178995454c7b979cf6ce086a8801e14c7"},
+    {file = "audioop_lts-0.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:78bfb3703388c780edf900be66e07de5a3d4105ca8e8720c5c4d67927e0b15d0"},
+    {file = "audioop_lts-0.2.1.tar.gz", hash = "sha256:e81268da0baa880431b68b1308ab7257eb33f356e57a5f9b1f915dfb13dd1387"},
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.13.3"
 description = "Screen-scraping library"
@@ -546,6 +590,29 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+
+[[package]]
+name = "discord-py"
+version = "2.5.2"
+description = "A Python wrapper for the Discord API"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "discord_py-2.5.2-py3-none-any.whl", hash = "sha256:81f23a17c50509ffebe0668441cb80c139e74da5115305f70e27ce821361295a"},
+    {file = "discord_py-2.5.2.tar.gz", hash = "sha256:01cd362023bfea1a4a1d43f5280b5ef00cad2c7eba80098909f98bf28e578524"},
+]
+
+[package.dependencies]
+aiohttp = ">=3.7.4,<4"
+audioop-lts = {version = "*", markers = "python_version >= \"3.13\""}
+
+[package.extras]
+dev = ["black (==22.6)", "typing_extensions (>=4.3,<5)"]
+docs = ["imghdr-lts (==1.0.0) ; python_version >= \"3.13\"", "sphinx (==4.4.0)", "sphinx-inline-tabs (==2023.4.21)", "sphinxcontrib-applehelp (==1.0.4)", "sphinxcontrib-devhelp (==1.0.2)", "sphinxcontrib-htmlhelp (==2.0.1)", "sphinxcontrib-jsmath (==1.0.1)", "sphinxcontrib-qthelp (==1.0.3)", "sphinxcontrib-serializinghtml (==1.1.5)", "sphinxcontrib-websupport (==1.2.4)", "sphinxcontrib_trio (==1.1.2)", "typing-extensions (>=4.3,<5)"]
+speed = ["Brotli", "aiodns (>=1.1) ; sys_platform != \"win32\"", "cchardet (==2.1.7) ; python_version < \"3.10\"", "orjson (>=3.5.4)", "zstandard (>=0.23.0)"]
+test = ["coverage[toml]", "pytest", "pytest-asyncio", "pytest-cov", "pytest-mock", "typing-extensions (>=4.3,<5)", "tzdata ; sys_platform == \"win32\""]
+voice = ["PyNaCl (>=1.3.0,<1.6)"]
 
 [[package]]
 name = "distlib"
@@ -1629,4 +1696,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "ec0b8b25a52860212dd8b3ba1ba0389ce0272fc557f273e5f0691ac98cdb8b32"
+content-hash = "ce73d5a32b8e761ef6dafda5d50b0dc768240dc3638c0d8546a869090ac44660"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ dependencies = [
     "python-dotenv (>=1.1.0,<2.0.0)",
     "fake-useragent (>=2.1.0,<3.0.0)",
     "pydantic (>=2.11.3,<3.0.0)",
-    "motor (>=3.7.0,<4.0.0)"
+    "motor (>=3.7.0,<4.0.0)",
+    "discord-py (>=2.5.2,<3.0.0)"
 ]
 
 


### PR DESCRIPTION
# Discord Bot 구현

## 주요 기능
이 PR에서는 discord에 기사를 발행하기위한 discord bot을 만들었습니다. 
이 코드는 discord server에 discord bot이 초대 되어 있어야 작동합니다.

1. **Discord 클라이언트**
   - Discord API와 통신하는 클라이언트 구현
   - 메시지 및 임베드 전송 기능
   - 채널 캐싱을 통한 성능 최적화

2. **포맷터**
   - 기사를 Discord 임베드 형식으로 변환
   - 카테고리별 색상 및 스타일 적용
   - 오류 메시지 포맷팅

## 기술 스택
- discord.py 라이브러리 활용
- Pydantic 기반 설정 관리
- 비동기 프로그래밍(asyncio)